### PR TITLE
fix: guard on children prop in useChildrenSize hook

### DIFF
--- a/hooks/useChildrenSize.ts
+++ b/hooks/useChildrenSize.ts
@@ -4,9 +4,9 @@ const render = (element: ReactElement | ReactElement[] | any) => {
   if (Array.isArray(element)) return element.map(i => render(i)).join('')
 
   const { children } = (element as ReactElement).props ?? { children: element }
-  if (Array.isArray(children) || children.props) return render(children)
+  if (Array.isArray(children) || children?.props) return render(children)
 
-  return children.toString()
+  return children?.toString() ?? ''
 }
 
 const getSize = (children: ReactElement | ReactElement[] | any) => {


### PR DESCRIPTION
Handle the case where children are not set in the props of the element.

Fixes this sort of error:

```
The above error occurred in the <View> component:

    at View (file:///Users/alex/Documents/Workspaces/libp2p/universal-connectivity/node-js-peer/node_modules/react-curse/index.js:1445:3)
    at text
    at Text (file:///Users/alex/Documents/Workspaces/libp2p/universal-connectivity/node-js-peer/node_modules/react-curse/index.js:580:17)
    at text
    at Text (file:///Users/alex/Documents/Workspaces/libp2p/universal-connectivity/node-js-peer/node_modules/react-curse/index.js:580:17)
    at Frame (file:///Users/alex/Documents/Workspaces/libp2p/universal-connectivity/node-js-peer/node_modules/react-curse/index.js:839:18)
    at PeerList (/Users/alex/Documents/Workspaces/libp2p/universal-connectivity/node-js-peer/src/components/peer-list.tsx:10:22)
    at App (/Users/alex/Documents/Workspaces/libp2p/universal-connectivity/node-js-peer/src/App.tsx:10:16)
    at ChatProvider (/Users/alex/Documents/Workspaces/libp2p/universal-connectivity/node-js-peer/src/context/chat.tsx:49:32)
    at AppWrapper (/Users/alex/Documents/Workspaces/libp2p/universal-connectivity/node-js-peer/src/context/index.tsx:28:30)
```

I've come across this case with this sort of thing:

```jsx
function MyElement () {
  return (
    <Text>Hello</Text>
  )
}

function Wrapper () {
  return (
    <Frame>
      <View>
        <MyElement />
      </View>
    </Frame>
  )
}
```

Weirdly it doesn't happen with:

```jsx
function Wrapper () {
  return (
    <Frame>
      <View>
        <Text>Hello</Text>
      </View>
    </Frame>
  )
}
```
